### PR TITLE
Fix typo: s/branch4/branch/

### DIFF
--- a/1-Repository/7-branching-and-the-power-of-rebase.md
+++ b/1-Repository/7-branching-and-the-power-of-rebase.md
@@ -53,7 +53,7 @@ There is a way, however, to transplant the `Z` branch straight onto `D`, effecti
 
 ![Rebase](../images/rebase.png)
 
-This state of affairs most directly represents what we’d like done: for our local, development branch `Z` to be based on the latest work in the main branch `D`. That’s why the command is called “rebase”, because it changes the base commit of the branch it’s run from. If you run it repeatedly, you can carry forward a set of patches indefinitely, always staying up-to-date with the main branch, but without adding unnecessary merge commits to your development branch4. Here are the commands to run, compared to the merge operation performed above:
+This state of affairs most directly represents what we’d like done: for our local, development branch `Z` to be based on the latest work in the main branch `D`. That’s why the command is called “rebase”, because it changes the base commit of the branch it’s run from. If you run it repeatedly, you can carry forward a set of patches indefinitely, always staying up-to-date with the main branch, but without adding unnecessary merge commits to your development branch. Here are the commands to run, compared to the merge operation performed above:
 
 ```bash
 $ git checkout Z # switch to the Z branch


### PR DESCRIPTION
Just fixing one more tiny typo; I didn't notice any others. Thanks for your work; this was a helpful read for me.