### PR TITLE
Script name/invocation agreement

### DIFF
--- a/4-Stashing-and-the-reflog.md
+++ b/4-Stashing-and-the-reflog.md
@@ -66,7 +66,7 @@ $ cat <<EOF > /usr/local/bin/git-snapshot
 git stash && git stash apply
 EOF
 $ chmod +x $_
-$ git snapshot
+$ git-snapshot
 ```
 
 There’s no reason you couldn’t run this from a `cron` job every hour, along with running the `reflog expire` command every week or month.


### PR DESCRIPTION
Changed line 69 to assure the invocation of the script defined on line 64 is successful ('$ git-snapshot'); as the definition of the script itself could also be changed (such that the script could be called "git_snapshot") apologies are in order if something else was intended but not understood...