### PR TITLE
fix shell command semantics

### DIFF
--- a/4-Stashing-and-the-reflog.md
+++ b/4-Stashing-and-the-reflog.md
@@ -65,7 +65,7 @@ $ cat <<EOF > /usr/local/bin/git-snapshot
 #!/bin/sh
 git stash && git stash apply
 EOF
-$ chmod +x $_
+$ chmod +x /usr/local/bin/git-snapshot
 $ git-snapshot
 ```
 


### PR DESCRIPTION
`$_` will expand to the last argument of the previous shell command, after expansion. 
The intention was to perform `chmod +x /usr/local/bin/git-snapshot`; 
however, what was happening was `chmod +x cat`.