### PR TITLE
Fix #15 - Windows note for hash

### DIFF
--- a/1-Repository/2-introducing-the-blob.md
+++ b/1-Repository/2-introducing-the-blob.md
@@ -4,7 +4,7 @@ Now that the basic picture has been painted, let’s get into some practical exa
 
 ```bash
 $ mkdir sample; cd sample
-$ echo 'Hello, world!' > greeting
+$ echo Hello, world!> greeting
 ```
 
 Here I’ve created a new filesystem directory named “sample” which contains a file whose contents are prosaically predictable. I haven’t even created a repository yet, but already I can start using some of Git’s commands to understand what it’s going to do. First of all, I’d like to know which hash id Git is going to store my greeting text under:
@@ -13,6 +13,8 @@ Here I’ve created a new filesystem directory named “sample” which contains
 $ git hash-object greeting
 af5626b4a114abcb82d63db7c8082c3c4756e51b
 ```
+
+NOTE this hash is for a file with LF new line endings. For Windows users that have `core.autocrlf` with a different value than `true`, this can generate a different hash.
 
 If you run this command on your system, you’ll get the same hash id. Even though we’re creating two different repositories (possibly a world apart, even) our greeting blob in those two repositories will have the same hash id. I could even pull commits from your repository into mine, and Git would realize that we’re tracking the same content — and so would only store one copy of it! Pretty cool.
 The next step is to initialize a new repository and commit the file into it. I’m going to do this all in one step right now, but then come back and do it again in stages so you can see what’s going on underneath:


### PR DESCRIPTION
Updated echo sample for "greeting" to be portable for both Unix/Linux and Windows.

The Microsoft Windows CMD echo treats both single and double quotes as values (not delimiters).