### PR TITLE
Remove problematic cron job suggestion for git-snapshot (fixes #29)

### DIFF
--- a/4-Stashing-and-the-reflog.md
+++ b/4-Stashing-and-the-reflog.md
@@ -70,4 +70,3 @@ $ chmod +x /usr/local/bin/git-snapshot
 $ git-snapshot
 ```
 
-There’s no reason you couldn’t run this from a `cron` job every hour, along with running the `reflog expire` command every week or month.


### PR DESCRIPTION
## Summary
- Removes the suggestion to run `git stash && git stash apply` from a cron job in the stashing documentation
- Addresses the valid concerns raised in issue #29 about potential problems with this approach

## Problem
The original suggestion to run the git-snapshot script from cron could cause:
- Editor "files have changed" prompts when files are modified by the stash operations
- Stash list pollution with garbage entries from automated runs
- Race conditions if cron runs during compilation or when actively editing files

## Solution
Removed the final sentence that suggested running the script from cron. The documentation still provides value by showing how to create the git-snapshot script for manual use.

## Test plan
- [x] Verified the documentation flow remains intact after the removal
- [x] Confirmed the git-snapshot script example is still complete and functional
- [x] Ensured no other references to automated stashing remain in the document

Fixes #29

🤖 Generated with [Claude Code](https://claude.ai/code)