### PR TITLE
Add explanations and links for Quilt and Stacked Git

### DIFF
--- a/2-The-Index/2-taking-the-index-further.md
+++ b/2-The-Index/2-taking-the-index-further.md
@@ -2,11 +2,11 @@
 
 Let’s see, the index... With it you can pre-stage a set of changes, thus iteratively building up a patch before committing it to the repository. Now, where have I heard that concept before...
 
-If you’re thinking “Quilt!”, you’re exactly right. In fact, the index is little different from Quilt, it just adds the restriction of allowing only one patch to be constructed at a time.
+If you're thinking "[Quilt](https://savannah.nongnu.org/projects/quilt)!", you're exactly right. Quilt is a patch management tool that allows you to manage a stack of patches on top of a base tree. In fact, the index is little different from Quilt, it just adds the restriction of allowing only one patch to be constructed at a time.
 
 But what if, instead of two sets of changes within `foo.c`, I had four? With plain Git, I’d have to tease each one out, commit it, and then tease out the next. This is made much easier using the index, but what if I wanted to test those changes in various combinations with each other before checking them in? That is, if I labelled the patches A, B, C and D, what if I wanted to test A + B, then A + C, then A + D, etc., before deciding if any of the changes were truly complete?
 
-There is no mechanism in Git itself that allows you to mix and match parallel sets of changes on the fly. Sure, multiple branches can let you do parallel development, and the index lets you stage multiple changes into a series of commits, but you can't do both at once: staging a series of patches while at the same time selectively enabling and disabling some of them, to verify the integrity of the patches in concert before finally committing them. What you'd need in order to do something like this would be an index which allows for greater depth than one commit at a time. This is exactly what Stacked Git provides.
+There is no mechanism in Git itself that allows you to mix and match parallel sets of changes on the fly. Sure, multiple branches can let you do parallel development, and the index lets you stage multiple changes into a series of commits, but you can't do both at once: staging a series of patches while at the same time selectively enabling and disabling some of them, to verify the integrity of the patches in concert before finally committing them. What you'd need in order to do something like this would be an index which allows for greater depth than one commit at a time. This is exactly what [Stacked Git (StGit)](https://stacked-git.github.io/) provides.
 
 Here’s how I’d commit two different patches into my working tree using plain Git:
 
@@ -28,7 +28,7 @@ $ git checkout master # go back to the master "branch"
 $ git branch -D work # remove my temporary branch
 ```
 
-Surely there has to be a better way! With `stg` I can queue up both patches and then re-apply them in whatever order I like, for independent or combined testing, etc. Here’s how I’d queue the same two patches from the previous example, using `stg`:
+Surely there has to be a better way! With `stg` (the Stacked Git command) I can queue up both patches and then re-apply them in whatever order I like, for independent or combined testing, etc. Here's how I'd queue the same two patches from the previous example, using `stg`:
 
 ```bash
 $ stg new patch1


### PR DESCRIPTION
## Summary
- Added link and explanation for Quilt patch management tool
- Added link and clarification for Stacked Git (StGit)
- Clarified that `stg` is the Stacked Git command

## Context
This PR addresses issue #23 where Quilt and Stacked Git were mentioned in the documentation without proper explanations or links to learn more about them.

## Changes
- Added a link to the Quilt project page with a brief explanation of what it is
- Added a link to the Stacked Git project page and clarified that StGit stands for Stacked Git
- Added clarification that `stg` is the Stacked Git command

Fixes #23

## Test plan
- [x] Verified markdown renders correctly with links
- [x] Checked that all references to Quilt and Stacked Git now have proper context

🤖 Generated with [Claude Code](https://claude.ai/code)