### PR TITLE
Fix CSS paragraph indentation after non-paragraph elements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,15 @@
+# Jekyll configuration for GitHub Pages
+title: Git from the Bottom Up
+description: A guide to understanding Git from first principles
+
+# Theme settings
+theme: jekyll-theme-hamilton
+
+# Custom CSS
+sass:
+  sass_dir: _sass
+  style: compressed
+
+# Include custom CSS
+plugins:
+  - jekyll-seo-tag

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,20 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/* Fix for paragraph indentation issue
+   See: https://github.com/jwiegley/git-from-the-bottom-up/issues/22
+   
+   The default theme incorrectly indents paragraphs after non-paragraph elements.
+   This fix ensures that only paragraphs immediately following other paragraphs
+   are indented, not paragraphs after code blocks or other elements.
+*/
+
+.main-content p {
+    text-indent: 0;
+}
+
+.main-content p + p {
+    text-indent: 1.5em;
+}


### PR DESCRIPTION
## Summary
- Fixes issue #22 where paragraphs were incorrectly indented after non-paragraph sibling elements
- Adds Jekyll configuration and custom CSS to override the problematic default theme styling
- Changes CSS selector logic from indenting all paragraphs except first-of-type to only indenting paragraphs that directly follow another paragraph

## Problem
The default Hamilton theme stylesheet was using:
```css
.main-content p { text-indent: 1.5em; }
.main-content p:first-of-type { text-indent: 0; }
```

This caused paragraphs after code blocks, images, and other non-paragraph elements to be incorrectly indented.

## Solution
The fix implements the CSS suggested in the issue:
```css
.main-content p { text-indent: 0; }
.main-content p + p { text-indent: 1.5em; }
```

This ensures only paragraphs directly following other paragraphs are indented, maintaining proper document formatting.

## Test plan
- [ ] Deploy changes to GitHub Pages
- [ ] Verify paragraph indentation is correct after code blocks
- [ ] Verify paragraph indentation is correct between consecutive paragraphs
- [ ] Check that the documentation renders correctly across different pages

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)